### PR TITLE
feat: Allow to change backend plugin url path

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -157,6 +157,18 @@ nobl9:
 
 Depending on where your Nobl9 organization is hosted, use either `https://app.nobl9.com` or `http://us1.nobl9.com` as the base URL.
 
+The backend plugin will be available under the `/api/nobl9/slos` path by default. You can use the `nobl9.backendPluginPath` config key to provide a custom path.
+If, for example, your backend plugins are served without the `/api` prefix, you can use the following config:
+
+```yaml
+nobl9:
+  baseUrl: https://app.nobl9.com
+  organization: ${NOBL9_ORGANIZATION_ID}
+  clientId: ${NOBL9_CLIENT_ID}
+  clientSecret: ${NOBL9_CLIENT_SECRET}
+  backendPluginPath: /nobl9/slos
+```
+
 #### Catalog entity annotations
 
 Annotate components of your choice with `nobl9.com/project` annotation and either `nobl9.com/services` and/or `nobl9.com/slos`. Based on multiple annotations, the `AND` operator is used to decide which SLOs to display.

--- a/plugins/nobl9-plugin/config.d.ts
+++ b/plugins/nobl9-plugin/config.d.ts
@@ -14,5 +14,10 @@ export interface Config {
      * @visibility frontend
      */
     organization: string;
+    /**
+     * custom backend plugin path
+     * @visibility frontend
+     */
+    backendPluginPath: string | undefined;
   };
 }

--- a/plugins/nobl9-plugin/package.json
+++ b/plugins/nobl9-plugin/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@backstage/catalog-model": "^1.4.3",
+    "@backstage/config": "^1.2.0",
     "@backstage/core-components": "^0.13.8",
     "@backstage/core-plugin-api": "^1.8.0",
     "@backstage/plugin-catalog-react": "^1.9.1",

--- a/plugins/nobl9-plugin/src/components/SloPage/SloPage.tsx
+++ b/plugins/nobl9-plugin/src/components/SloPage/SloPage.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Grid, Typography } from '@material-ui/core';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
+import { Config } from '@backstage/config';
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { SloGridItem } from '../SloGrid';
@@ -58,6 +59,14 @@ const toQueryStringParams = (entity: Entity) => {
   return params.toString();
 };
 
+const getBackendUrl = (config: Config, entity: Entity) => {
+  const baseUrl = config.getString('backend.baseUrl');
+  const path = config.has('nobl9.backendPluginPath')
+    ? config.getString('nobl9.backendPluginPath')
+    : '/api/nobl9/slos';
+  return `${baseUrl}${path}?${toQueryStringParams(entity)}`;
+};
+
 export const SloPage = () => {
   const { entity } = useEntity();
   const config = useApi(configApiRef);
@@ -65,11 +74,7 @@ export const SloPage = () => {
 
   const { value, loading, error } =
     useAsync(async (): Promise<N9BackendResponse> => {
-      return await fetch(
-        `${config.getString(
-          'backend.baseUrl',
-        )}/api/nobl9/slos?${toQueryStringParams(entity)}`,
-      ).then(res => res.json());
+      return await fetch(getBackendUrl(config, entity)).then(res => res.json());
     }, [entity]);
 
   if (loading) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,6 +2169,14 @@
     "@backstage/types" "^1.1.1"
     lodash "^4.17.21"
 
+"@backstage/config@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@backstage/config/-/config-1.2.0.tgz#6a4d93197d0586ee3a40f9e4877c5cfd76c128f3"
+  integrity sha512-tW8hNzDTClotYmpOrUrutymzZ0Zimx/WeU2+5tLv+ZI8ssRV64KGRe8hi7PuQz2lARVF1DxjwV//Bq2VjR5veA==
+  dependencies:
+    "@backstage/errors" "^1.2.4"
+    "@backstage/types" "^1.1.1"
+
 "@backstage/core-app-api@^1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@backstage/core-app-api/-/core-app-api-1.11.1.tgz#21584a43cf7bc80171b8f03a3c0db80b1adef424"
@@ -2269,6 +2277,14 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.3.tgz#6418d3ece63b13d14e32d44ec4db0f8866b0b1c9"
   integrity sha512-3YtYRKLNeRaSCzKSikNFoemesacDoEY0UwZAq7lnzCCpiCpSCfg7UA4y7wfjadFFU9Pd6nckUg2BzOk9keL15w==
+  dependencies:
+    "@backstage/types" "^1.1.1"
+    serialize-error "^8.0.1"
+
+"@backstage/errors@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@backstage/errors/-/errors-1.2.4.tgz#2ba79c6308e87b0de99edf499e1c82477d3d6e8a"
+  integrity sha512-JBhKn9KwZTzp/AaOC0vBncKCM1vI9Z8rKKyr9vj3wt3SSgCnDPxNwVz7SlXa2Rc9TOQq0Yk3olkmQE9U+S5uWg==
   dependencies:
     "@backstage/types" "^1.1.1"
     serialize-error "^8.0.1"
@@ -16772,16 +16788,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16855,7 +16862,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16868,13 +16875,6 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18282,7 +18282,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18295,15 +18295,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR extends the `nobl9` config section with the `backendPluginPath` key. 

By default, the nobl9 backend plugin is available under the `/api/nobl9/slos` path. You can now use the `nobl9.backendPluginPath` config key to provide a custom one.

If, for example, your backend plugins are served without the `/api` prefix, you can use the following config:

```yaml
nobl9:
  baseUrl: https://app.nobl9.com
  organization: ${NOBL9_ORGANIZATION_ID}
  clientId: ${NOBL9_CLIENT_ID}
  clientSecret: ${NOBL9_CLIENT_SECRET}
  backendPluginPath: /nobl9/slos
```