### PR TITLE
chore: Prettier should ignore changelog.md

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ dist-types
 app-config.yaml
 lerna.json
 renovate.json
+**/CHANGELOG.md


### PR DESCRIPTION
## Motivation

`CHANGELOG.MD` files are autogenerated by lerna, and since there is a known issue with formatting https://github.com/lerna/lerna/issues/2565 we need to ignore them from being verified by prettier.

## Testing

- Just see that checks are passing
