### PR TITLE
chore: Add backend config to schema

### DIFF
--- a/plugins/nobl9-plugin/config.d.ts
+++ b/plugins/nobl9-plugin/config.d.ts
@@ -19,5 +19,15 @@ export interface Config {
      * @visibility frontend
      */
     backendPluginPath?: string;
+    /**
+     * Client ID for the nobl9 API credentials
+     * @visibility backend
+     */
+    clientId: string;
+    /**
+     * Client Secret of the nobl9 API credentials
+     * @visibility secret
+     */
+    clientSecret: string;
   };
 }


### PR DESCRIPTION
## Motivation

While using the [DevTools plugin](https://github.com/backstage/backstage/blob/master/plugins/devtools/README.md) we noticed that the `clientSecret` was being exposed in plain text. 

By marking its visibility we can get it to be redacted in that config view.

## Summary

Added the missing configuration fields to the `config.d.ts` file. I'm not sure if they should be in this file in the frontend plugin or if you prefer that I create a new file in the backend plugin instead. Happy to do the changes if needed.


## Release Notes

Ensure that the config fields for the credentials have the correct visibility and are redacted in the Config view of the devTools plugin.

