### PR TITLE
fix: resolve security vulnerabilities in lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "tar": "7.5.11",
     "bfj": "9.1.3",
     "fast-xml-parser": "5.5.9",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "@backstage/cli-common": "0.1.17",
     "rollup": "4.59.0",
     "svgo": "2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13272,10 +13272,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@4.17.23, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
-  version "4.17.23"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
-  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+lodash@4.18.1, lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0, log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
## Summary

- Update **lodash** 4.17.23 → 4.18.1 via yarn resolution

Resolves:
- #207 Code Injection via `_.template` imports key names (high)
- #206 Prototype Pollution via array path bypass in `_.unset` and `_.omit` (moderate)

## Test plan

- [x] `yarn install` succeeds
- [x] `yarn build` succeeds
- [ ] CI passes