### PR TITLE
fix: bump axios to 1.16.0 to resolve security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "koa": "2.16.4",
     "react-markdown": "10.0.0",
     "tar-fs": "2.1.4",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "@babel/runtime": "7.26.10",
     "prismjs": "1.30.0",
     "webpack-dev-server": "5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7040,12 +7040,12 @@ axe-core@^4.10.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.2.tgz#85228e3e1d8b8532a27659b332e39b7fa0e022df"
   integrity sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==
 
-axios@1.15.0, axios@^1.7.4:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@1.16.0, axios@^1.7.4:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.16.0.tgz#f8e5dd931cef2a5f8c32216d5784eda2f8750eb7"
+  integrity sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
   dependencies:
-    follow-redirects "^1.15.11"
+    follow-redirects "^1.16.0"
     form-data "^4.0.5"
     proxy-from-env "^2.1.0"
 
@@ -10209,7 +10209,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@1.16.0, follow-redirects@^1.0.0, follow-redirects@^1.15.11:
+follow-redirects@1.16.0, follow-redirects@^1.0.0, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==


### PR DESCRIPTION
## Summary
- Bumps `axios` from `1.15.0` → `1.16.0` (in `resolutions`), refreshes `yarn.lock`.
- Addresses 12 open Dependabot alerts on axios:
  - **High**: prototype pollution gadgets (response tampering, data exfiltration, request hijacking); header injection via prototype pollution; HTTP-adapter read-side gadgets enabling credential injection / request hijacking; incomplete fix for CVE-2025-62718 (NO_PROXY bypass via 127.0.0.0/8 loopback subnet).
  - **Moderate**: `no_proxy` bypass via IP alias (SSRF); invisible JSON response tampering via `parseReviver`; XSRF token cross-origin leakage via `withXSRFToken` boolean coercion; CRLF injection in `multipart/form-data` body via unsanitized `blob.type` in `formDataToStream`; auth bypass via `validateStatus` merge strategy.
  - **Low**: null byte injection via reverse-encoding in `AxiosURLSearchParams`.

## Test plan
- [x] `yarn install` resolves cleanly with axios 1.16.0
- [x] `yarn tsc` passes
- [ ] Confirm Dependabot closes the 12 axios alerts after merge