### PR TITLE
fix: resolve Dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "sha.js": "2.4.12",
     "http-proxy-middleware": "2.0.9",
     "on-headers": "1.1.0",
-    "tmp": "0.2.4",
+    "tmp": "0.2.6",
     "mdast-util-to-hast": "13.2.1",
-    "qs": "6.14.2",
+    "qs": "6.15.2",
     "tar": "7.5.11",
     "bfj": "9.1.3",
     "fast-xml-parser": "5.7.2",
@@ -93,7 +93,8 @@
     "follow-redirects": "1.16.0",
     "typescript-json-schema": "0.67.0",
     "uuid": "14.0.0",
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "js-cookie": "3.0.7"
   },
   "prettier": "@spotify/prettier-config",
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -12755,10 +12755,10 @@ jose@^5.0.0:
   resolved "https://registry.yarnpkg.com/jose/-/jose-5.10.0.tgz#c37346a099d6467c401351a9a0c2161e0f52c4be"
   integrity sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==
 
-js-cookie@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+js-cookie@3.0.7, js-cookie@^2.2.1:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
+  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -16507,10 +16507,10 @@ pvutils@^1.1.3, pvutils@^1.1.5:
   resolved "https://registry.yarnpkg.com/pvutils/-/pvutils-1.1.5.tgz#84b0dea4a5d670249aa9800511804ee0b7c2809c"
   integrity sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==
 
-qs@6.13.0, qs@6.14.2, qs@^6.11.0, qs@^6.11.2, qs@^6.12.3, qs@^6.9.4, qs@~6.14.0, qs@~6.15.1, qs@~6.5.2:
-  version "6.14.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.2.tgz#b5634cf9d9ad9898e31fba3504e866e8efb6798c"
-  integrity sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==
+qs@6.13.0, qs@6.15.2, qs@^6.11.0, qs@^6.11.2, qs@^6.12.3, qs@^6.9.4, qs@~6.14.0, qs@~6.15.1, qs@~6.5.2:
+  version "6.15.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.2.tgz#fd55426d710403ddccc45e0f9eab16db7727ece9"
+  integrity sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==
   dependencies:
     side-channel "^1.1.0"
 
@@ -18738,10 +18738,10 @@ tinyglobby@^0.2.9:
     fdir "^6.4.3"
     picomatch "^4.0.2"
 
-tmp@0.2.4, tmp@^0.0.33, tmp@~0.2.1:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
-  integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==
+tmp@0.2.6, tmp@^0.0.33, tmp@~0.2.1:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 tmpl@1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary

Resolves the 3 open Dependabot security alerts by bumping pinned transitive dependencies to their patched versions via the root `resolutions` block.

| Package | From | To | Severity | Advisory |
|---------|------|----|----------|----------|
| `tmp` | 0.2.4 | 0.2.6 | High | [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) — path traversal via unsanitized prefix/postfix |
| `js-cookie` | 2.2.1 | 3.0.7 | High | [GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j) — per-instance prototype hijack in `assign()` |
| `qs` | 6.14.2 | 6.15.2 | Medium | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) — remotely triggerable DoS in `qs.stringify` |

`tmp` and `qs` were already pinned (at vulnerable versions); `js-cookie` (pulled in transitively via `react-use`) is newly pinned. `js-cookie` is a major bump (2.x → 3.x) — the advisory has no 2.x patch line.

## Testing

- `yarn tsc` passes
- Lockfile regenerated with `yarn install`; diff is limited to the three target packages