### PR TITLE
chore: bump http-proxy-middleware to 3.0.7 (security)

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "linkifyjs": "4.3.2",
     "undici": "7.28.0",
     "sha.js": "2.4.12",
-    "http-proxy-middleware": "3.0.6",
+    "http-proxy-middleware": "3.0.7",
     "on-headers": "1.1.0",
     "tmp": "0.2.7",
     "mdast-util-to-hast": "13.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11562,10 +11562,10 @@ http-proxy-agent@^7.0.0:
     agent-base "^7.1.0"
     debug "^4.3.4"
 
-http-proxy-middleware@3.0.6, http-proxy-middleware@^2.0.9:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.6.tgz#5c11d604f94bef39c30f8f3a5e1ed571634c3ca0"
-  integrity sha512-jhO3QfahaHWfQjEnyGW0vpYIYaXcnA6FEfehrBthOokGppvmI6zcV+1yb6TWn3vyeh8yQUoEqH51DNHOCjivxg==
+http-proxy-middleware@3.0.7, http-proxy-middleware@^2.0.9:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz#53d3a1fe175bcacc507711cc52a0b32baf2c3442"
+  integrity sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==
   dependencies:
     "@types/http-proxy" "^1.17.15"
     debug "^4.3.6"


### PR DESCRIPTION
## Summary

Follow-up to the previous Dependabot security PR. Bumps the pinned `http-proxy-middleware` resolution from `3.0.6` to **`3.0.7`** to fix a newly-disclosed high-severity advisory.

## Alert fixed

| Alert | Package | Severity | Vulnerable range | Patched |
|---|---|---|---|---|
| #270 | `http-proxy-middleware` | **high** | `>= 3.0.4, < 3.0.7` | **3.0.7** |

> multipart/form-data field injection via unescaped CRLF in `fixRequestBody`.

The previous PR moved `http-proxy-middleware` from `2.0.9` → `3.0.6`; `3.0.6` sits inside this newly-published vulnerable range, so this bumps it one more patch to `3.0.7`. As before, it's a dev/build-time transitive dependency of `webpack-dev-server` (the plugin ships only `dist`), and this repo configures no dev-server proxy.

## Other open alerts (no action)

- **#263 `js-yaml` (moderate)** — already fixed by the previous PR (lockfile resolves to `4.2.0`, zero `4.1.x` copies). Dependabot just hasn't re-scanned `main` yet; it will auto-close.
- **#120 `elliptic` (low)** — no patched release exists upstream; already pinned to the latest `6.6.1`.

## Verification

- `yarn tsc` ✅
- `yarn build` ✅
- `yarn lint` ✅
- `yarn prettier --check .` ✅
- `yarn.lock` confirmed to resolve `http-proxy-middleware` to `3.0.7` with no `3.0.6` copies remaining.