### PR TITLE
chore: bump websocket-driver to 0.7.5 (security) PC-20177

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "axios": "1.16.0",
     "@babel/runtime": "7.26.10",
     "prismjs": "1.30.0",
-    "webpack-dev-server": "5.2.5",
+    "webpack-dev-server": "5.2.6",
     "fast-uri": "3.1.2",
     "ip-address": "10.1.1",
     "@tootallnate/once": "3.0.1",

--- a/plugins/nobl9-backend-plugin/package.json
+++ b/plugins/nobl9-backend-plugin/package.json
@@ -60,7 +60,7 @@
     "axios": "1.16.0",
     "@babel/runtime": "7.26.10",
     "prismjs": "1.30.0",
-    "webpack-dev-server": "5.2.5",
+    "webpack-dev-server": "5.2.6",
     "pbkdf2": "3.1.3",
     "form-data": "4.0.6",
     "on-headers": "1.1.0",

--- a/plugins/nobl9-plugin/package.json
+++ b/plugins/nobl9-plugin/package.json
@@ -73,7 +73,7 @@
     "axios": "1.16.0",
     "@babel/runtime": "7.26.10",
     "prismjs": "1.30.0",
-    "webpack-dev-server": "5.2.5",
+    "webpack-dev-server": "5.2.6",
     "pbkdf2": "3.1.3",
     "on-headers": "1.1.0",
     "tmp": "0.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13300,7 +13300,7 @@ language-tags@^1.0.9:
   dependencies:
     language-subtag-registry "^0.3.20"
 
-launch-editor@2.14.1, launch-editor@^2.6.1:
+launch-editor@2.14.1, launch-editor@^2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.14.1.tgz#f7e0da3f58aaea03fea01074d840b5f739ed7ddc"
   integrity sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==
@@ -19688,10 +19688,10 @@ webpack-dev-middleware@^7.4.2:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@5.2.2, webpack-dev-server@5.2.5:
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz#648fceaac6a5736b0935e5c1e55d6aa1d0626119"
-  integrity sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==
+webpack-dev-server@5.2.2, webpack-dev-server@5.2.6:
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz#3a5d41233cbb7504f814d19e59a59173fb8ae23d"
+  integrity sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==
   dependencies:
     "@types/bonjour" "^3.5.13"
     "@types/connect-history-api-fallback" "^1.5.4"
@@ -19711,7 +19711,7 @@ webpack-dev-server@5.2.2, webpack-dev-server@5.2.5:
     graceful-fs "^4.2.6"
     http-proxy-middleware "^2.0.9"
     ipaddr.js "^2.1.0"
-    launch-editor "^2.6.1"
+    launch-editor "^2.14.1"
     open "^10.0.3"
     p-retry "^6.2.0"
     schema-utils "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19723,9 +19723,9 @@ webpack-dev-server@5.2.2, webpack-dev-server@5.2.5:
     ws "^8.18.0"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
Fixed Dependabot alert #276 (CVE-2026-54466 / GHSA-xv26-6w52-cph6, critical): websocket-driver message corruption via abuse of protocol length headers. Jira: [PC-20177](https://nobl9.atlassian.net/browse/PC-20177)

| | Before | After |
|---|---|---|
| websocket-driver | 0.7.4 | 0.7.5 (patched) |
| webpack-dev-server (resolution) | 5.2.5 | 5.2.6 |

websocket-driver: the patched version satisfies the existing semver ranges (`>=0.5.1`, `^0.7.4`), so this is a lockfile-only re-resolution - no `resolutions` entry needed. The package is transitive via sockjs/faye-websocket under webpack-dev-server.

## Also in this PR

- Bumped the existing webpack-dev-server `resolutions` pin from 5.2.5 to 5.2.6 (latest 5.x, patch release). v6 was considered but not taken: it is a major requiring Node >= 22.15 and the v5 API is what `@backstage/cli`'s `@rspack/dev-server` (which pins 5.2.2 exactly) programmatically consumes.


[PC-20177]: https://nobl9.atlassian.net/browse/PC-20177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ